### PR TITLE
Implement io.Reader

### DIFF
--- a/cmd/kinesumer/cmd_tail.go
+++ b/cmd/kinesumer/cmd_tail.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"fmt"
+	"io"
+	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/color"
@@ -70,8 +71,7 @@ func runTail(ctx *cli.Context) {
 		panic(err)
 	}
 	defer k.End()
-	for {
-		rec := <-k.Records()
-		fmt.Println(string(rec.Data()))
-	}
+
+	r := kinesumer.NewReader(k.Records())
+	io.Copy(os.Stdout, r)
 }

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,77 @@
+package kinesumer
+
+import (
+	"io"
+
+	k "github.com/remind101/kinesumer/interface"
+)
+
+// Reader provides an io.Reader implementation that can read data from a kinesis
+// stream.
+type Reader struct {
+	records <-chan k.Record
+
+	// buffered data for the current record.
+	buf []byte
+	// done is called when the current buffer is fully consumed.
+	done func()
+}
+
+// NewReader returns a new Reader instance that reads data from records.
+func NewReader(records <-chan k.Record) *Reader {
+	return &Reader{records: records}
+}
+
+// Read implements io.Reader Read. Read will copy <= len(b) bytes from the kinesis
+// stream into b.
+func (r *Reader) Read(b []byte) (n int, err error) {
+	for {
+		// If there's no data in the buffer, we'll grab the next record
+		// and set the internal buffer to point to the data in that
+		// record. When all data from buf is read, Done() will be called
+		// on the record.
+		if len(r.buf) == 0 {
+			select {
+			case record, ok := <-r.records:
+				if !ok {
+					// Channel is closed, return io.EOF.
+					err = io.EOF
+					return
+				}
+
+				r.buf = record.Data()
+				r.done = record.Done
+			default:
+				// By convention, Read should return rather than wait
+				// for data to become available. If no data is available
+				// at this time, we'll return what we've copied
+				// so far.
+				return
+			}
+		}
+
+		n += r.copy(b[n:])
+		if n == len(b) {
+			return
+		}
+	}
+
+	return
+}
+
+// copy copies as much as it can from r.buf into b. If it succeeds in copying
+// all of the data, r.done is called.
+func (r *Reader) copy(b []byte) (n int) {
+	n += copy(b, r.buf)
+	if len(r.buf) >= n {
+		// If there's still some buffered data left, truncate the buffer
+		// and return.
+		r.buf = r.buf[n:]
+	}
+
+	if len(r.buf) == 0 {
+		r.done()
+	}
+
+	return
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,138 @@
+package kinesumer
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	k "github.com/remind101/kinesumer/interface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReader_Read_NoData(t *testing.T) {
+	ch := make(chan k.Record)
+	r := NewReader(ch)
+
+	b := make([]byte, 1)
+	n, err := r.Read(b)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestReader_Read_SingleByte(t *testing.T) {
+	ch := make(chan k.Record, 1)
+	checkpointC := make(chan k.Record, 1)
+	r := NewReader(ch)
+
+	// Check that we can read a single byte into a byte slice of size 1.
+	record := &Record{data: []byte{0x01}, checkpointC: checkpointC}
+	ch <- record
+	b := make([]byte, 1)
+
+	n, err := r.Read(b)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, []byte{0x01}, b)
+	assertCheckpointed(t, checkpointC, record)
+}
+
+func TestReader_Read_SmallBuffer(t *testing.T) {
+	ch := make(chan k.Record, 1)
+	checkpointC := make(chan k.Record, 1)
+	r := NewReader(ch)
+
+	// Check that, if the record has more data than the size of the buffer
+	// we're provided, we buffer the data.
+	record := &Record{data: []byte{0x01, 0x02}, checkpointC: checkpointC}
+	ch <- record
+	b := make([]byte, 1)
+
+	n, err := r.Read(b)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, []byte{0x01}, b)
+	assertNotCheckpointed(t, checkpointC)
+
+	n, err = r.Read(b)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, []byte{0x02}, b)
+	assertCheckpointed(t, checkpointC, record)
+}
+
+func TestReader_Read_LargeBuffer(t *testing.T) {
+	ch := make(chan k.Record, 2)
+	checkpointC := make(chan k.Record, 2)
+	r := NewReader(ch)
+
+	record := &Record{data: []byte{0x01}, checkpointC: checkpointC}
+	ch <- record
+	b := make([]byte, 2)
+
+	n, err := r.Read(b)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, []byte{0x01, 0x00}, b)
+	assertCheckpointed(t, checkpointC, record)
+
+	record = &Record{data: []byte{0x01}, checkpointC: checkpointC}
+	ch <- record
+	n, err = r.Read(b)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, []byte{0x01, 0x00}, b)
+	assertCheckpointed(t, checkpointC, record)
+}
+
+func TestReader_Read_MultipleRecords(t *testing.T) {
+	ch := make(chan k.Record, 2)
+	checkpointC := make(chan k.Record, 2)
+	r := NewReader(ch)
+
+	record1 := &Record{data: []byte{0x01}, checkpointC: checkpointC}
+	ch <- record1
+	record2 := &Record{data: []byte{0x02}, checkpointC: checkpointC}
+	ch <- record2
+
+	b := make([]byte, 2)
+	n, err := r.Read(b)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, []byte{0x01, 0x02}, b)
+
+	assertCheckpointed(t, checkpointC, record1)
+	assertCheckpointed(t, checkpointC, record2)
+}
+
+func TestReader_Read_Copy(t *testing.T) {
+	ch := make(chan k.Record, 2)
+	checkpointC := make(chan k.Record, 2)
+	r := NewReader(ch)
+
+	ch <- &Record{data: []byte{'a'}, checkpointC: checkpointC}
+	ch <- &Record{data: []byte{'b'}, checkpointC: checkpointC}
+	close(ch)
+
+	b := new(bytes.Buffer)
+
+	_, err := io.Copy(b, r)
+	assert.Nil(t, err)
+	assert.Equal(t, "ab", b.String())
+}
+
+func assertCheckpointed(t testing.TB, checkpointC chan k.Record, record k.Record) {
+	select {
+	case r := <-checkpointC:
+		assert.Equal(t, record, r)
+	default:
+		t.Fatalf("Expected Done to be called on record: %v", record)
+	}
+}
+
+func assertNotCheckpointed(t testing.TB, checkpointC chan k.Record) {
+	select {
+	case <-checkpointC:
+		t.Fatal("Expected no checkpoint")
+	default:
+	}
+}


### PR DESCRIPTION
This adds a `Reader` struct that implements [io.Reader](http://golang.org/pkg/io/#Reader). This allows you to treat kinesis streams as a plain old stream of bytes, allowing you to use things like io.Copy:

``` go
stream := kinesumer.NewReader(k.Records())
io.Copy(os.Stdout, stream)
```

Closes https://github.com/remind101/kinesumer/issues/15

**TODO**
- [x] Add a `NewReader` factory method.
