### PR TITLE
Sync should only sync shards it knows about

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmd/kinesumer/kinesumer
 .env
+.idea


### PR DESCRIPTION
Currently, it fetches all state from redis and saves it every `savePeriod`. When multiple processes are running, this can cause processes that are not working on a shard to overwrite the state of processes that are working on it.

@v-yarotsky @matthewdu 
