### PR TITLE
Throttle calls to GetRecords

### DIFF
--- a/shard_worker.go
+++ b/shard_worker.go
@@ -23,6 +23,7 @@ type ShardWorker struct {
 	errHandler             func(k.Error)
 	defaultIteratorType    string
 	shardIteratorTimestamp time.Time
+	getRecordsThrottle     <-chan time.Time
 	GetRecordsLimit        int64
 }
 
@@ -53,6 +54,8 @@ func (s *ShardWorker) TryGetShardIterator(iteratorType string, sequence string, 
 }
 
 func (s *ShardWorker) GetRecords(it string) ([]*kinesis.Record, string, int64, error) {
+	<-s.getRecordsThrottle
+
 	resp, err := s.kinesis.GetRecords(&kinesis.GetRecordsInput{
 		Limit:         &s.GetRecordsLimit,
 		ShardIterator: &it,

--- a/shard_worker_test.go
+++ b/shard_worker_test.go
@@ -23,6 +23,10 @@ func makeTestShardWorker() (*ShardWorker, *mocks.Kinesis, *mocks.Checkpointer, *
 	stopped := make(chan Unit, 1)
 	c := make(chan k.Record, 100)
 
+	// No throttling in tests
+	getRecordsThrottle := make(chan time.Time)
+	close(getRecordsThrottle)
+
 	return &ShardWorker{
 		kinesis: kin,
 		shard: &kinesis.Shard{
@@ -38,15 +42,16 @@ func makeTestShardWorker() (*ShardWorker, *mocks.Kinesis, *mocks.Checkpointer, *
 			},
 			ShardId: aws.String("shard0"),
 		},
-		checkpointer:    sssm,
-		stream:          "TestStream",
-		sequence:        "123",
-		stop:            stop,
-		stopped:         stopped,
-		c:               c,
-		provisioner:     prov,
-		errHandler:      DefaultErrHandler,
-		GetRecordsLimit: 123,
+		checkpointer:       sssm,
+		stream:             "TestStream",
+		sequence:           "123",
+		stop:               stop,
+		stopped:            stopped,
+		c:                  c,
+		provisioner:        prov,
+		errHandler:         DefaultErrHandler,
+		getRecordsThrottle: getRecordsThrottle,
+		GetRecordsLimit:    123,
 	}, kin, sssm, prov, stop, stopped, c
 }
 


### PR DESCRIPTION
https://github.com/remind101/kinesumer/issues/26

This will throttle calls to GetRecords to a maximum of 5 calls per second, by default, which is recommended in the Kinesis documentation.
